### PR TITLE
Use GA version of `azure-monitor-opentelemetry`

### DIFF
--- a/modules/databricks/main.tf
+++ b/modules/databricks/main.tf
@@ -164,7 +164,7 @@ resource "databricks_cluster" "default" {
 resource "databricks_library" "opentelemetry" {
   cluster_id = databricks_cluster.default.id
   pypi {
-    package = "azure-monitor-opentelemetry~=1.0.0b10"
+    package = "azure-monitor-opentelemetry~=1.0.0"
   }
 }
 


### PR DESCRIPTION
Since September 14th, [`azure-monitor-opentelemetry`](https://pypi.org/project/azure-monitor-opentelemetry/#description) has been released as GA. This PR ensures that we use the latest non-prerelease version.